### PR TITLE
Update DropObjectsNotInSource to false in controlDB deployment

### DIFF
--- a/.github/workflows/ControlDB-deployment.yml
+++ b/.github/workflows/ControlDB-deployment.yml
@@ -18,7 +18,7 @@ jobs:
             connection-string: ${{secrets.CONTROLDB_CONNECTIONSTRING}}
             path: ${{github.workspace}}\elt-framework\ControlDB\ELT\Database.sqlproj
             action: 'Publish'
-            arguments: '/p:DropPermissionsNotInSource=false /p:BlockOnPossibleDataLoss=false /p:DropRoleMembersNotInSource=false /p:DropObjectsNotInSource=true /p:IgnoreColumnOrder=true /p:IgnorePermissions=true'
+            arguments: '/p:DropPermissionsNotInSource=false /p:BlockOnPossibleDataLoss=false /p:DropRoleMembersNotInSource=false /p:DropObjectsNotInSource=false /p:IgnoreColumnOrder=true /p:IgnorePermissions=true'
         - name: Azure Logout
           run: |
             az logout


### PR DESCRIPTION

This pull request includes a change to the deployment workflow for the ControlDB project. The most important change is the modification of the arguments passed to the `Publish` action.

Deployment workflow update:

* [`.github/workflows/ControlDB-deployment.yml`](diffhunk://#diff-d807ce16f5aed4ac1a208c0a8d3a0cd63cc440b0e45e5d8b14ddfb53560ba72bL21-R21): Changed the `arguments` parameter in the `Publish` action to not drop objects that are not in the source by setting `/p:DropObjectsNotInSource=false`.