### PR TITLE
Fabric SQL updates to database deployment

### DIFF
--- a/.github/workflows/ControlDB-deployment.yml
+++ b/.github/workflows/ControlDB-deployment.yml
@@ -18,7 +18,15 @@ jobs:
             connection-string: ${{secrets.CONTROLDB_CONNECTIONSTRING}}
             path: ${{github.workspace}}\elt-framework\ControlDB\ELT\Database.sqlproj
             action: 'Publish'
-            arguments: '/p:DropPermissionsNotInSource=false /p:BlockOnPossibleDataLoss=false /p:DropRoleMembersNotInSource=false /p:DropObjectsNotInSource=false /p:IgnoreColumnOrder=true /p:IgnorePermissions=true /p:AllowIncompatiblePlatform=true /p:ExcludeObjectTypes=Logins;Users'
+            arguments: >
+              /p:DropPermissionsNotInSource=false
+              /p:BlockOnPossibleDataLoss=false
+              /p:DropRoleMembersNotInSource=false
+              /p:DropObjectsNotInSource=false
+              /p:IgnoreColumnOrder=true
+              /p:IgnorePermissions=true
+              /p:AllowIncompatiblePlatform=true
+              /p:ExcludeObjectTypes=Logins;Users
         - name: Azure Logout
           run: |
             az logout

--- a/.github/workflows/ControlDB-deployment.yml
+++ b/.github/workflows/ControlDB-deployment.yml
@@ -18,7 +18,7 @@ jobs:
             connection-string: ${{secrets.CONTROLDB_CONNECTIONSTRING}}
             path: ${{github.workspace}}\elt-framework\ControlDB\ELT\Database.sqlproj
             action: 'Publish'
-            arguments: '/p:DropPermissionsNotInSource=false /p:BlockOnPossibleDataLoss=false /p:DropRoleMembersNotInSource=false /p:DropObjectsNotInSource=false /p:IgnoreColumnOrder=true /p:IgnorePermissions=true'
+            arguments: '/p:DropPermissionsNotInSource=false /p:BlockOnPossibleDataLoss=false /p:DropRoleMembersNotInSource=false /p:DropObjectsNotInSource=false /p:IgnoreColumnOrder=true /p:IgnorePermissions=true /p:AllowIncompatiblePlatform=true /p:ExcludeObjectTypes=Logins;Users'
         - name: Azure Logout
           run: |
             az logout


### PR DESCRIPTION
This pull request updates the deployment workflow for the ControlDB project to enhance compatibility and exclude specific object types during publishing. The most important change modifies the `arguments` parameter in the deployment configuration.

### Deployment workflow updates:

* [`.github/workflows/ControlDB-deployment.yml`](diffhunk://#diff-d807ce16f5aed4ac1a208c0a8d3a0cd63cc440b0e45e5d8b14ddfb53560ba72bL21-R21): Updated the `arguments` parameter in the `Publish` action to include `/p:AllowIncompatiblePlatform=true` and `/p:ExcludeObjectTypes=Logins;Users`, improving deployment flexibility and excluding logins and users from the deployment process.