### PR TITLE
Refactor GetTransformInstance_L2 procedure to simplify conditions and…

### DIFF
--- a/elt-framework/ControlDB/ELT/Stored Procedures/GetTransformInstance_L2.sql
+++ b/elt-framework/ControlDB/ELT/Stored Procedures/GetTransformInstance_L2.sql
@@ -56,9 +56,6 @@ begin
 				AND (L2TI.[ActiveFlag]=1 OR L2TI.[ReRunL2TransformFlag]=1)
 				AND L2TI.[L2TransformInstanceID] = COALESCE(@L2TransformInstanceId, L2TI.[L2TransformInstanceID])
 				AND (L2TI.[L2TransformStatus] IS NULL OR L2TI.[L2TransformStatus] NOT IN ('Running','DWUpload'))  --Fetch new instances and ignore instances that are currently running
-				AND ID.[DelayL2TransformationFlag] = COALESCE(@DelayL2TransformationFlag,ID.[DelayL2TransformationFlag])
-				AND L2TD.[InputType] like COALESCE(@InputType,L2TD.[InputType])
-				--AND ISNULL(L2TI.RetryCount,0) <= L2TD.MaxRetries
-				AND  L2TI.[L2TransformID]= (CASE WHEN @L2TransformID=0 then  L2TI.[L2TransformID] ELSE  @L2TransformID END)
+				AND L2TD.[InputType] like COALESCE(@InputType,L2TD.[InputType])				
 			ORDER BY L2TD.RunSequence ASC, L2TI.[L2TransformInstanceID] ASC
 END


### PR DESCRIPTION
This pull request makes minor adjustments to the filtering logic in the SQL stored procedure `GetTransformInstance_L2.sql`. The changes simplify the selection criteria by removing a filter related to delayed transformations and a commented-out retry count check.

Filtering logic simplification:

* Removed the condition on `ID.[DelayL2TransformationFlag]`, so the query no longer filters by the delayed transformation flag.
* Deleted a commented-out line that checked if `RetryCount` was less than or equal to `MaxRetries`, which has no effect on execution but cleans up the code.… improve readability