### PR TITLE
Enhance GetTransformInstance_L2 procedure by adding conditions for De…

### DIFF
--- a/elt-framework/ControlDB/ELT/Stored Procedures/GetTransformInstance_L2.sql
+++ b/elt-framework/ControlDB/ELT/Stored Procedures/GetTransformInstance_L2.sql
@@ -3,7 +3,7 @@
 	@StreamName varchar(100) = '%',
 	@MaxTransformInstance int = 10,
 	@L2TransformInstanceId INT = NULL, --To fetch all transform instances set Parameter as NULL otherwise provide a specific instance id
-	@DelayL2TransformationFlag INT=NULL, --Pass @DelayL2TransformationFlag=0 to fetch all instances that needs to be transformed in the current pipeline (usually the ingestion pipeline). Pass =1 to fetch @DelayL2TransformationFlagh all transformations that are scheduled for a later time.
+	@DelayL2TransformationFlag INT= NULL, --Pass @DelayL2TransformationFlag=0 to fetch all instances that needs to be transformed in the current pipeline (usually the ingestion pipeline). Pass =1 to fetch @DelayL2TransformationFlagh all transformations that are scheduled for a later time.
 	@InputType varchar(15)	= '%',
 	@L2TransformID INT=0 --To Fetch all transformations for a specific stream pass 0 otherwise provide TransformId prersent in L2Transsformdefinition
 AS
@@ -56,6 +56,8 @@ begin
 				AND (L2TI.[ActiveFlag]=1 OR L2TI.[ReRunL2TransformFlag]=1)
 				AND L2TI.[L2TransformInstanceID] = COALESCE(@L2TransformInstanceId, L2TI.[L2TransformInstanceID])
 				AND (L2TI.[L2TransformStatus] IS NULL OR L2TI.[L2TransformStatus] NOT IN ('Running','DWUpload'))  --Fetch new instances and ignore instances that are currently running
+			    AND ID.[DelayL2TransformationFlag] = COALESCE(@DelayL2TransformationFlag,ID.[DelayL2TransformationFlag])
+				AND ISNULL(L2TI.RetryCount,0) <= L2TD.MaxRetries
 				AND L2TD.[InputType] like COALESCE(@InputType,L2TD.[InputType])				
 			ORDER BY L2TD.RunSequence ASC, L2TI.[L2TransformInstanceID] ASC
 END


### PR DESCRIPTION
This pull request updates the logic in the `GetTransformInstance_L2.sql` stored procedure to improve how transform instances are selected for processing. The changes add new filtering criteria to ensure that only eligible instances are considered based on delay flags and retry counts.

Enhancements to instance selection logic:

* Added a filter to check that `ID.[DelayL2TransformationFlag]` matches the provided `@DelayL2TransformationFlag` parameter, ensuring instances are only selected if their delay flag aligns with the input.
* Added a condition to limit selection to instances where `ISNULL(L2TI.RetryCount,0)` is less than or equal to `L2TD.MaxRetries`, preventing over-retries beyond the configured maximum.…layL2TransformationFlag and RetryCount to improve instance selection logic