### PR TITLE
Add condition for L2TransformID in GetTransformInstance_L2 procedure …

### DIFF
--- a/elt-framework/ControlDB/ELT/Stored Procedures/GetTransformInstance_L2.sql
+++ b/elt-framework/ControlDB/ELT/Stored Procedures/GetTransformInstance_L2.sql
@@ -59,5 +59,6 @@ begin
 			    AND ID.[DelayL2TransformationFlag] = COALESCE(@DelayL2TransformationFlag,ID.[DelayL2TransformationFlag])
 				AND ISNULL(L2TI.RetryCount,0) <= L2TD.MaxRetries
 				AND L2TD.[InputType] like COALESCE(@InputType,L2TD.[InputType])				
+				AND  L2TI.[L2TransformID] = COALESCE(@L2TransformID,L2TI.[L2TransformID])
 			ORDER BY L2TD.RunSequence ASC, L2TI.[L2TransformInstanceID] ASC
 END


### PR DESCRIPTION
This pull request introduces a small change to the filtering logic in the `GetTransformInstance_L2.sql` stored procedure. The change adds an additional filter to the SQL query to match records based on the `L2TransformID` parameter if it is provided. This improves the precision of the results returned by the procedure.

* Query filtering improvement: Added a condition to the SQL query to filter results by `L2TI.[L2TransformID]` using the `@L2TransformID` parameter, increasing query specificity.…to enhance instance filtering logic