### PR TITLE
Update Azure/sql-action From v2.0 to @v2.3

### DIFF
--- a/.github/workflows/ControlDB-deployment.yml
+++ b/.github/workflows/ControlDB-deployment.yml
@@ -13,7 +13,7 @@ jobs:
           with:
            creds: '{"clientId":"${{ secrets.CLIENT_ID }}","clientSecret":"${{ secrets.CLIENT_SECRET }}","subscriptionId":"${{ secrets.SUBSCRIPTION_ID }}","tenantId":"${{ secrets.TENANT_ID }}"}'
         - name: Build and Deploy SQL Database
-          uses: Azure/sql-action@v2
+          uses: Azure/sql-action@v2.3
           with:
             connection-string: ${{secrets.CONTROLDB_CONNECTIONSTRING}}
             path: ${{github.workspace}}\elt-framework\ControlDB\ELT\Database.sqlproj
@@ -25,6 +25,7 @@ jobs:
               /p:DropObjectsNotInSource=false
               /p:IgnoreColumnOrder=true
               /p:IgnorePermissions=true
+              /p:IgnorePostDeployScript=false
               /p:AllowIncompatiblePlatform=true
               /p:ExcludeObjectTypes=Logins;Users
         - name: Azure Logout

--- a/.github/workflows/ControlDB-deployment.yml
+++ b/.github/workflows/ControlDB-deployment.yml
@@ -45,23 +45,6 @@ jobs:
               /p:AllowIncompatiblePlatform=true
               /p:ExcludeObjectTypes=Logins;Users
 
-        # - name: Build and Deploy SQL Database
-        #   uses: Azure/sql-action@v2.3
-        #   with:
-        #     connection-string: ${{secrets.CONTROLDB_CONNECTIONSTRING}}
-        #     path: ${{github.workspace}}\elt-framework\ControlDB\ControlDB.sqlproj
-        #     action: 'Publish'
-        #     arguments: >
-        #       /p:DropPermissionsNotInSource=false
-        #       /p:BlockOnPossibleDataLoss=false
-        #       /p:DropRoleMembersNotInSource=false
-        #       /p:DropObjectsNotInSource=false
-        #       /p:IgnoreColumnOrder=true
-        #       /p:IgnorePermissions=true
-        #       /p:IgnorePostDeployScript=false
-        #       /p:AllowIncompatiblePlatform=true
-        #       /p:ExcludeObjectTypes=Logins;Users
-
         - name: Azure Logout
           run: |
             az logout

--- a/.github/workflows/ControlDB-deployment.yml
+++ b/.github/workflows/ControlDB-deployment.yml
@@ -6,18 +6,34 @@ jobs:
       steps:
         - name: Checkout code 
           uses: actions/checkout@v3
+
         - name: Display checkout files and folders
           run: Get-ChildItem ${{github.workspace}} -Recurse
+
         - name: Azure Login
           uses: Azure/login@v1
           with:
            creds: '{"clientId":"${{ secrets.CLIENT_ID }}","clientSecret":"${{ secrets.CLIENT_SECRET }}","subscriptionId":"${{ secrets.SUBSCRIPTION_ID }}","tenantId":"${{ secrets.TENANT_ID }}"}'
-        - name: Build and Deploy SQL Database
+
+        # Ensure MSBuild is available on PATH
+        - name: Setup MSBuild 
+          uses: microsoft/setup-msbuild@v2
+
+        # Build the SQL project into a .dacpac using MSBuild (SSDT)
+        - name: Build ControlDB dacpac
+          shell: pwsh
+          run: |
+            msbuild "${{ github.workspace }}\elt-framework\ControlDB\ControlDB.sqlproj" `
+              /p:Configuration=Release `
+              /p:Platform="Any CPU"
+
+        # Deploy using the dacpac from previous step
+        - name: Deploy ControlDB
           uses: Azure/sql-action@v2.3
           with:
-            connection-string: ${{secrets.CONTROLDB_CONNECTIONSTRING}}
-            path: ${{github.workspace}}\elt-framework\ControlDB\ControlDB.sqlproj
-            action: 'Publish'
+            connection-string: ${{ secrets.CONTROLDB_CONNECTIONSTRING }}
+            path: ${{ github.workspace }}\elt-framework\ControlDB\bin\Release\ControlDB.dacpac
+            action: Publish
             arguments: >
               /p:DropPermissionsNotInSource=false
               /p:BlockOnPossibleDataLoss=false
@@ -28,6 +44,24 @@ jobs:
               /p:IgnorePostDeployScript=false
               /p:AllowIncompatiblePlatform=true
               /p:ExcludeObjectTypes=Logins;Users
+
+        # - name: Build and Deploy SQL Database
+        #   uses: Azure/sql-action@v2.3
+        #   with:
+        #     connection-string: ${{secrets.CONTROLDB_CONNECTIONSTRING}}
+        #     path: ${{github.workspace}}\elt-framework\ControlDB\ControlDB.sqlproj
+        #     action: 'Publish'
+        #     arguments: >
+        #       /p:DropPermissionsNotInSource=false
+        #       /p:BlockOnPossibleDataLoss=false
+        #       /p:DropRoleMembersNotInSource=false
+        #       /p:DropObjectsNotInSource=false
+        #       /p:IgnoreColumnOrder=true
+        #       /p:IgnorePermissions=true
+        #       /p:IgnorePostDeployScript=false
+        #       /p:AllowIncompatiblePlatform=true
+        #       /p:ExcludeObjectTypes=Logins;Users
+
         - name: Azure Logout
           run: |
             az logout

--- a/.github/workflows/ControlDB-deployment.yml
+++ b/.github/workflows/ControlDB-deployment.yml
@@ -32,7 +32,7 @@ jobs:
           uses: Azure/sql-action@v2.3
           with:
             connection-string: ${{ secrets.CONTROLDB_CONNECTIONSTRING }}
-            path: ${{ github.workspace }}\elt-framework\ControlDB\bin\Release\ControlDB.dacpac
+            path: ${{ github.workspace }}\elt-framework\ControlDB\bin\Output\ControlDB.dacpac
             action: Publish
             arguments: >
               /p:DropPermissionsNotInSource=false

--- a/.github/workflows/ControlDB-deployment.yml
+++ b/.github/workflows/ControlDB-deployment.yml
@@ -16,7 +16,7 @@ jobs:
           uses: Azure/sql-action@v2.3
           with:
             connection-string: ${{secrets.CONTROLDB_CONNECTIONSTRING}}
-            path: ${{github.workspace}}\ControlDB\ControlDB.sqlproj
+            path: ${{github.workspace}}\elt-framework\ControlDB\ControlDB.sqlproj
             action: 'Publish'
             arguments: >
               /p:DropPermissionsNotInSource=false

--- a/.github/workflows/ControlDB-deployment.yml
+++ b/.github/workflows/ControlDB-deployment.yml
@@ -16,7 +16,7 @@ jobs:
           uses: Azure/sql-action@v2.3
           with:
             connection-string: ${{secrets.CONTROLDB_CONNECTIONSTRING}}
-            path: ${{github.workspace}}\ControlDB\ELT\Database.sqlproj
+            path: ${{github.workspace}}\ControlDB\ControlDB.sqlproj
             action: 'Publish'
             arguments: >
               /p:DropPermissionsNotInSource=false

--- a/.github/workflows/ControlDB-deployment.yml
+++ b/.github/workflows/ControlDB-deployment.yml
@@ -16,7 +16,7 @@ jobs:
           uses: Azure/sql-action@v2.3
           with:
             connection-string: ${{secrets.CONTROLDB_CONNECTIONSTRING}}
-            path: ${{github.workspace}}\elt-framework\ControlDB\ELT\Database.sqlproj
+            path: ${{github.workspace}}\ControlDB\ELT\Database.sqlproj
             action: 'Publish'
             arguments: >
               /p:DropPermissionsNotInSource=false


### PR DESCRIPTION
This pull request updates the deployment workflow for the ControlDB SQL project in the GitHub Actions pipeline. The main changes involve switching from direct project deployment to building a `.dacpac` file with MSBuild before deploying, improving build transparency and reliability.

**Build and deployment process improvements:**

* Added a step to display all checked-out files and folders for easier troubleshooting and verification.
* Introduced a dedicated MSBuild setup step to ensure the build environment is properly configured.
* Replaced direct deployment of the SQL project with a two-step process: first building a `.dacpac` using MSBuild, then deploying the generated `.dacpac` file using `Azure/sql-action@v2.3`.

**Deployment configuration changes:**

* Updated the deployment path to point to the built `.dacpac` file instead of the `.sqlproj` file, and added the `/p:IgnorePostDeployScript=false` argument to the deployment command for finer control over post-deployment scripts.