### PR TITLE
Config scripts for ASQL Mirrored database ELT pattern

### DIFF
--- a/elt-framework/ControlDB/ControlDB.sqlproj
+++ b/elt-framework/ControlDB/ControlDB.sqlproj
@@ -80,6 +80,7 @@
     <Folder Include="Post Deployment Script\datasources\UploadFiles" />
     <Folder Include="Post Deployment Script\datasources\UploadFiles\IngestDefinition" />
     <Folder Include="Post Deployment Script\datasources\UploadFiles\L1TransformDefinition" />
+    <Folder Include="Post Deployment Script\datasources\ASQLMirror" />
   </ItemGroup>
   <ItemGroup>
     <Build Include="ELT\ELT.sql" />
@@ -198,6 +199,15 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
     <None Include="Post Deployment Script\datasources\UploadFiles\L1TransformDefinition\L1T_CustomFormRecognizerModel.sql" />
+    <None Include="Post Deployment Script\datasources\ASQLMirror\ASQLMirror_IngestDefinition.sql">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="Post Deployment Script\datasources\ASQLMirror\ASQLMirror_L1TransformDefinition.sql">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="Post Deployment Script\datasources\ASQLMirror\ASQLMirror_L2TransformDefinition.sql">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <PostDeploy Include="Post Deployment Script\Script.PostDeployment.sql">

--- a/elt-framework/ControlDB/ELT/Indexes/UI_L1TransformDefinition.sql
+++ b/elt-framework/ControlDB/ELT/Indexes/UI_L1TransformDefinition.sql
@@ -1,3 +1,3 @@
 ﻿CREATE UNIQUE INDEX [UI_L1TransformDefinition]
 	ON [ELT].[L1TransformDefinition]
-	([InputRawFileSystem],[InputRawFileFolder],[InputRawFile],[InputRawTable],[OutputL1CurateFileSystem],[OutputL1CuratedFolder],[OutputL1CuratedFile])
+	([InputRawFileSystem],[InputRawFileFolder],[InputRawFile],[InputRawTable],[OutputL1CurateFileSystem],[OutputL1CuratedFolder],[OutputL1CuratedFile],[OutputDWTable])

--- a/elt-framework/ControlDB/ELT/Indexes/UI_L1TransformInstance.sql
+++ b/elt-framework/ControlDB/ELT/Indexes/UI_L1TransformInstance.sql
@@ -1,3 +1,3 @@
 ﻿CREATE UNIQUE INDEX [UI_L1TransformInstance]
 	ON [ELT].[L1TransformInstance]
-	([InputRawFileSystem],[InputRawFileFolder],[InputRawFile],[InputRawTable],[DataFromTimestamp],[DataToTimestamp],[OutputL1CurateFileSystem],[OutputL1CuratedFolder],[OutputL1CuratedFile])
+	([InputRawFileSystem],[InputRawFileFolder],[InputRawFile],[InputRawTable],[DataFromTimestamp],[DataToTimestamp],[OutputL1CurateFileSystem],[OutputL1CuratedFolder],[OutputL1CuratedFile],[OutputDWTable])

--- a/elt-framework/ControlDB/ELT/Indexes/UI_L2TransformDefinition.sql
+++ b/elt-framework/ControlDB/ELT/Indexes/UI_L2TransformDefinition.sql
@@ -1,3 +1,3 @@
 ﻿CREATE UNIQUE INDEX [UI_L2TransformDefinition]
 	ON [ELT].[L2TransformDefinition]
-	([InputFileSystem],[InputFileFolder],[InputFile],[InputDWTable],[OutputL2CurateFileSystem],[OutputL2CuratedFolder],[OutputL2CuratedFile])
+	([InputFileSystem],[InputFileFolder],[InputFile],[InputDWTable],[OutputL2CurateFileSystem],[OutputL2CuratedFolder],[OutputL2CuratedFile],[OutputDWTable])

--- a/elt-framework/ControlDB/ELT/Indexes/UI_L2TransformInstance.sql
+++ b/elt-framework/ControlDB/ELT/Indexes/UI_L2TransformInstance.sql
@@ -1,3 +1,3 @@
 ﻿CREATE INDEX [UI_L2TransformInstance]
 	ON [ELT].[L2TransformInstance]
-	([InputFileSystem],[InputFileFolder],[InputFile],[InputDWTable],[OutputL2CurateFileSystem],[OutputL2CuratedFolder],[OutputL2CuratedFile])
+	([InputFileSystem],[InputFileFolder],[InputFile],[InputDWTable],[OutputL2CurateFileSystem],[OutputL2CuratedFolder],[OutputL2CuratedFile],[OutputDWTable])

--- a/elt-framework/ControlDB/Post Deployment Script/Script.PostDeployment.sql
+++ b/elt-framework/ControlDB/Post Deployment Script/Script.PostDeployment.sql
@@ -10,12 +10,17 @@ Post-Deployment Script Template
 --------------------------------------------------------------------------------------
 */
 
---IngestDefinition
-:r .\datasources\RestAPI\IngestDefinition\PurviewRestAPI.sql
-:r .\datasources\RestAPI\IngestDefinition\AzureRestAPI.sql
-:r .\datasources\UploadFiles\IngestDefinition\CustomFormRecognizerModel.sql
+----IngestDefinition
+--:r .\datasources\RestAPI\IngestDefinition\PurviewRestAPI.sql
+--:r .\datasources\RestAPI\IngestDefinition\AzureRestAPI.sql
+--:r .\datasources\UploadFiles\IngestDefinition\CustomFormRecognizerModel.sql
 
---L1TransformDefinition
-:r .\datasources\RestAPI\L1TransformDefinition\L1T_PurviewRestAPI.sql
-:r .\datasources\RestAPI\L1TransformDefinition\L1T_AzureRestAPI.sql
-:r .\datasources\UploadFiles\L1TransformDefinition\L1T_CustomFormRecognizerModel.sql
+----L1TransformDefinition
+--:r .\datasources\RestAPI\L1TransformDefinition\L1T_PurviewRestAPI.sql
+--:r .\datasources\RestAPI\L1TransformDefinition\L1T_AzureRestAPI.sql
+--:r .\datasources\UploadFiles\L1TransformDefinition\L1T_CustomFormRecognizerModel.sql
+
+--Ingest Definition for Mirrored ASQL
+:r .\datasources\ASQLMirror\ASQLMirror_IngestDefinition.sql
+:r .\datasources\ASQLMirror\ASQLMirror_L1TransformDefinition.sql
+:r .\datasources\ASQLMirror\ASQLMirror_L2TransformDefinition.sql

--- a/elt-framework/ControlDB/Post Deployment Script/datasources/ASQLMirror/ASQLMirror_IngestDefinition.sql
+++ b/elt-framework/ControlDB/Post Deployment Script/datasources/ASQLMirror/ASQLMirror_IngestDefinition.sql
@@ -1,0 +1,182 @@
+﻿IF OBJECT_ID('tempdb..#ASQLMirror_IngestDefinition') IS NOT NULL DROP TABLE #ASQLMirror_IngestDefinition;
+
+--Create Temp table with same structure as IngestDefinition
+CREATE TABLE #ASQLMirror_IngestDefinition
+(
+	[SourceSystemName] [varchar](50) NOT NULL,
+	[StreamName] [varchar](100) NULL,
+	[SourceSystemDescription] [varchar](200) NULL,
+	[Backend] [varchar](30) NULL,
+	[EntityName] [varchar](100) NULL,
+	[WatermarkColName] [varchar](50) NULL,
+	[LastDeltaDate] [datetime2](7) NULL,
+    [DestinationRawTable] [varchar](200) NULL,
+	[ActiveFlag] [bit] NOT NULL,
+	[L1TransformationReqdFlag] [bit] NOT NULL,
+	[L2TransformationReqdFlag] [bit] NOT NULL,
+	[DelayL1TransformationFlag] [bit] NOT NULL,
+	[DelayL2TransformationFlag] [bit] NOT NULL
+);
+
+--Application.PaymentMethods
+INSERT INTO #ASQLMirror_IngestDefinition
+SELECT 'WWI-mirror' AS [SourceSystemName],
+    'PaymentMethods' AS [StreamName],
+    'Azure SQL Mirror Source System' AS [SourceSystemDescription],
+    'ASQLMirror' AS [Backend],
+    'Application.PaymentMethods' AS [EntityName],
+    NULL AS [WatermarkColName],
+    NULL AS [LastDeltaDate],
+    'Application.PaymentMethods' AS [DestinationRawTable],
+    1 AS [ActiveFlag],
+    1 AS [L1TransformationReqdFlag],
+    0 AS [L2TransformationReqdFlag],
+    0 AS [DelayL1TransformationFlag],
+    0 AS [DelayL2TransformationFlag]
+
+UNION
+--Application.People
+SELECT 'WWI-mirror' AS [SourceSystemName],
+    'People' AS [StreamName],
+    'Azure SQL Mirror Source System' AS [SourceSystemDescription],
+    'ASQLMirror' AS [Backend],
+    'Application.People' AS [EntityName],
+    NULL AS [WatermarkColName],
+    NULL AS [LastDeltaDate],
+    'Application.People' AS [DestinationRawTable],
+    1 AS [ActiveFlag],
+    1 AS [L1TransformationReqdFlag],
+    0 AS [L2TransformationReqdFlag],
+    0 AS [DelayL1TransformationFlag],
+    0 AS [DelayL2TransformationFlag]
+
+UNION
+--Application.TransactionTypes
+SELECT 'WWI-mirror' AS [SourceSystemName],
+    'TransactionTypes' AS [StreamName],
+    'Azure SQL Mirror Source System' AS [SourceSystemDescription],
+    'ASQLMirror' AS [Backend],
+    'Application.TransactionTypes' AS [EntityName],
+    NULL AS [WatermarkColName],
+    NULL AS [LastDeltaDate],
+    'Application.TransactionTypes' AS [DestinationRawTable],
+    1 AS [ActiveFlag],
+    1 AS [L1TransformationReqdFlag],
+    0 AS [L2TransformationReqdFlag],
+    0 AS [DelayL1TransformationFlag],
+    0 AS [DelayL2TransformationFlag] 
+
+UNION
+--Purchasing.PurchaseOrders
+SELECT 'WWI-mirror' AS [SourceSystemName],
+    'PurchaseOrders' AS [StreamName],
+    'Azure SQL Mirror Source System' AS [SourceSystemDescription],
+    'ASQLMirror' AS [Backend],
+    'Purchasing.PurchaseOrders' AS [EntityName],
+    'LastEditedWhen' AS [WatermarkColName],
+    '1900-01-01' AS [LastDeltaDate],
+    'Purchasing.PurchaseOrders' AS [DestinationRawTable],
+    1 AS [ActiveFlag],
+    1 AS [L1TransformationReqdFlag],
+    1 AS [L2TransformationReqdFlag],
+    0 AS [DelayL1TransformationFlag],
+    0 AS [DelayL2TransformationFlag]    
+
+UNION
+--Purchasing.SupplierTransactions
+SELECT 'WWI-mirror' AS [SourceSystemName],
+    'SupplierTransactions' AS [StreamName],
+    'Azure SQL Mirror Source System' AS [SourceSystemDescription],
+    'ASQLMirror' AS [Backend],
+    'Purchasing.SupplierTransactions' AS [EntityName],
+    'LastEditedWhen' AS [WatermarkColName],
+    '1900-01-01' AS [LastDeltaDate],
+    'Purchasing.SupplierTransactions' AS [DestinationRawTable],
+    1 AS [ActiveFlag],
+    1 AS [L1TransformationReqdFlag],
+    1 AS [L2TransformationReqdFlag],
+    0 AS [DelayL1TransformationFlag],
+    0 AS [DelayL2TransformationFlag]       
+
+UNION
+--Sales.CustomerTransactions
+SELECT 'WWI-mirror' AS [SourceSystemName],
+    'CustomerTransactions' AS [StreamName],
+    'Azure SQL Mirror Source System' AS [SourceSystemDescription],
+    'ASQLMirror' AS [Backend],
+    'Sales.CustomerTransactions' AS [EntityName],
+    'LastEditedWhen' AS [WatermarkColName],
+    '1900-01-01' AS [LastDeltaDate],
+    'Sales.CustomerTransactions' AS [DestinationRawTable],
+    1 AS [ActiveFlag],
+    1 AS [L1TransformationReqdFlag],
+    1 AS [L2TransformationReqdFlag],
+    0 AS [DelayL1TransformationFlag],
+    0 AS [DelayL2TransformationFlag]          
+
+UNION
+--Sales.Orders
+SELECT 'WWI-mirror' AS [SourceSystemName],
+    'Orders' AS [StreamName],
+    'Azure SQL Mirror Source System' AS [SourceSystemDescription],
+    'ASQLMirror' AS [Backend],
+    'Sales.Orders' AS [EntityName],
+    'LastEditedWhen' AS [WatermarkColName],
+    '1900-01-01' AS [LastDeltaDate],
+    'Sales.Orders' AS [DestinationRawTable],
+    1 AS [ActiveFlag],
+    1 AS [L1TransformationReqdFlag],
+    1 AS [L2TransformationReqdFlag],
+    0 AS [DelayL1TransformationFlag],
+    0 AS [DelayL2TransformationFlag]           
+;
+
+--Merge with IngestDefinition for re-runnability
+MERGE INTO [ELT].[IngestDefinition] AS tgt
+USING #ASQLMirror_IngestDefinition AS src
+ON src.[SourceSystemName]=tgt.[SourceSystemName] AND src.[StreamName]=tgt.[StreamName]
+WHEN MATCHED THEN
+    UPDATE SET tgt.[SourceSystemDescription] = src.[SourceSystemDescription],
+               tgt.[Backend] = src.[Backend],
+               tgt.[EntityName] = src.[EntityName],
+               tgt.[WatermarkColName] = src.[WatermarkColName],
+               tgt.[LastDeltaDate] = src.[LastDeltaDate],
+               tgt.[DestinationRawTable] = src.[DestinationRawTable],
+               tgt.[ActiveFlag] = src.[ActiveFlag],
+               tgt.[L1TransformationReqdFlag]  = src.[L1TransformationReqdFlag],
+               tgt.[L2TransformationReqdFlag] = src.[L2TransformationReqdFlag],
+               tgt.[DelayL1TransformationFlag] = src.[DelayL1TransformationFlag],
+               tgt.[DelayL2TransformationFlag] = src.[DelayL2TransformationFlag],
+               tgt.[ModifiedBy] = USER_NAME(),
+               tgt.[ModifiedTimestamp] = GetDate()
+WHEN NOT MATCHED BY TARGET THEN
+    INSERT(	[SourceSystemName],
+            [StreamName],
+            [SourceSystemDescription],
+            [Backend],
+            [EntityName],
+            [WatermarkColName],
+            [LastDeltaDate],
+            [DestinationRawTable],
+            [ActiveFlag],
+            [L1TransformationReqdFlag],
+            [L2TransformationReqdFlag],
+            [DelayL1TransformationFlag],
+            [DelayL2TransformationFlag],
+            [ModifiedBy],
+            [ModifiedTimestamp])
+    VALUES (src.[SourceSystemName],
+            src.[StreamName],
+            src.[SourceSystemDescription],
+            src.[Backend],
+            src.[EntityName],
+            src.[WatermarkColName],
+            src.[LastDeltaDate],
+            src.[DestinationRawTable],			
+            src.[ActiveFlag],
+            src.[L1TransformationReqdFlag],
+            src.[L2TransformationReqdFlag],
+            src.[DelayL1TransformationFlag],
+            src.[DelayL2TransformationFlag],			
+            USER_NAME(),
+            GetDate());

--- a/elt-framework/ControlDB/Post Deployment Script/datasources/ASQLMirror/ASQLMirror_L1TransformDefinition.sql
+++ b/elt-framework/ControlDB/Post Deployment Script/datasources/ASQLMirror/ASQLMirror_L1TransformDefinition.sql
@@ -1,0 +1,80 @@
+﻿IF OBJECT_ID('tempdb..#ASQLMirror_L1TransformDefinition') IS NOT NULL DROP TABLE #ASQLMirror_L1TransformDefinition;
+
+--Create Temp table with same structure as L1TransformDefinition
+CREATE TABLE #ASQLMirror_L1TransformDefinition(
+	[IngestID] [int] NOT NULL,
+	[ComputeName] [varchar](100) NULL,
+    [InputRawTable] [varchar](200) NULL,
+	[LookupColumns] [varchar](4000) NULL,
+	[OutputDWTable] [varchar](200) NULL,
+	[OutputDWTableWriteMode] [varchar](20) NULL,
+    [OutputL1CurateFileSystem] varchar(50) not null,
+	[OutputL1CuratedFolder] varchar(200) not null,
+	[OutputL1CuratedFile] varchar(200) not null,
+	[WatermarkColName] [varchar](50) NULL,
+	[ActiveFlag] [bit] NOT NULL
+    );
+
+INSERT INTO #ASQLMirror_L1TransformDefinition
+    SELECT  [IngestID]
+    ,'L1Transform-Generic-Fabric' AS [ComputeName]
+    ,[DestinationRawTable] AS [InputRawTable]
+    , (CASE [EntityName]
+			WHEN 'Purchasing.PurchaseOrders' THEN 'PurchaseOrderID' 
+			WHEN 'Purchasing.SupplierTransactions' THEN 'SupplierTransactionID'
+			WHEN 'Sales.CustomerTransactions' THEN 'CustomerTransactionID'
+			WHEN 'Sales.Orders' THEN 'OrderID'
+			ELSE NULL 
+		END) AS [LookupColumns]
+    , 'silver.Mirror_'+ Replace([EntityName],'.','_')  [OutputDWTable]
+    ,(CASE WHEN [WatermarkColName] IS NOT NULL THEN 'append' ELSE 'overwrite' END) AS [OutputDWTableWriteMode]
+    ,'Tables' AS [OutputL1CurateFileSystem]
+    ,SUBSTRING([EntityName],1,CHARINDEX('.', [EntityName])) AS [OutputL1CuratedFolder]
+    ,SUBSTRING([EntityName], (CHARINDEX('.',[EntityName])+1)) AS [OutputL1CuratedFile]    
+    , [WatermarkColName]
+    , 1 AS [ActiveFlag]
+    FROM  [ELT].[IngestDefinition]
+    WHERE [SourceSystemName]='WWI-mirror'
+    AND [ActiveFlag]=1;
+
+    --Merge with Temp table for re-runnability
+    MERGE INTO [ELT].[L1TransformDefinition] AS TARGET
+    USING #ASQLMirror_L1TransformDefinition AS SOURCE
+    ON TARGET.OutputDWTable = SOURCE.OutputDWTable
+    AND TARGET.InputRawTable = SOURCE.InputRawTable
+    WHEN MATCHED THEN 
+        UPDATE SET 
+            TARGET.IngestID = SOURCE.IngestID,
+            TARGET.ComputeName = SOURCE.ComputeName,
+            TARGET.InputRawTable = SOURCE.InputRawTable,
+            TARGET.LookupColumns = SOURCE.LookupColumns,
+            TARGET.OutputDWTable = SOURCE.OutputDWTable,
+            TARGET.OutputDWTableWriteMode = SOURCE.OutputDWTableWriteMode,
+            TARGET.OutputL1CurateFileSystem = SOURCE.OutputL1CurateFileSystem,
+            TARGET.OutputL1CuratedFolder = SOURCE.OutputL1CuratedFolder,
+            TARGET.OutputL1CuratedFile = SOURCE.OutputL1CuratedFile,
+            TARGET.WatermarkColName = SOURCE.WatermarkColName,
+            TARGET.ActiveFlag = SOURCE.ActiveFlag
+    WHEN NOT MATCHED BY TARGET THEN
+        INSERT (IngestID, 
+                ComputeName, 
+                InputRawTable, 
+                LookupColumns, 
+                OutputDWTable, 
+                OutputDWTableWriteMode,
+                OutputL1CurateFileSystem, 
+                OutputL1CuratedFolder, 
+                OutputL1CuratedFile, 
+                WatermarkColName, 
+                ActiveFlag)
+        VALUES (SOURCE.IngestID, 
+                SOURCE.ComputeName,
+                SOURCE.InputRawTable,
+                SOURCE.LookupColumns,
+                SOURCE.OutputDWTable,
+                SOURCE.OutputDWTableWriteMode,
+                SOURCE.OutputL1CurateFileSystem,
+                SOURCE.OutputL1CuratedFolder,
+                SOURCE.OutputL1CuratedFile,
+                SOURCE.WatermarkColName,
+                SOURCE.ActiveFlag);

--- a/elt-framework/ControlDB/Post Deployment Script/datasources/ASQLMirror/ASQLMirror_L2TransformDefinition.sql
+++ b/elt-framework/ControlDB/Post Deployment Script/datasources/ASQLMirror/ASQLMirror_L2TransformDefinition.sql
@@ -1,0 +1,71 @@
+﻿IF OBJECT_ID('tempdb..#ASQLMirror_L2TransformDefinition') IS NOT NULL DROP TABLE #ASQLMirror_L2TransformDefinition;
+
+CREATE TABLE #ASQLMirror_L2TransformDefinition(
+	[IngestID] [int] NULL,
+	[L1TransformID] [int] NULL,
+	[ComputeName] [varchar](100) NULL,
+	[InputFileSystem] [varchar](50) NULL,
+	[InputFileFolder] [varchar](200) NULL,
+	[InputFile] [varchar](200) NULL,
+	[InputDWTable] [varchar](200) NULL,
+	[OutputDWTable] [varchar](200) NULL,
+	[OutputDWTableWriteMode] [varchar](20) NULL,
+	[ActiveFlag] [bit] NOT NULL
+    );
+
+Insert into #ASQLMirror_L2TransformDefinition
+SELECT 
+    L1.[IngestID]
+    ,L1.[L1TransformID]
+    ,'gold.mirror_create_'+ Trim(Lower(I.StreamName)) + '_monthly_snapshot'  AS [ComputeName]
+    ,L1.[OutputL1CurateFileSystem] AS [InputFileSystem]
+    ,L1.[OutputL1CuratedFolder] AS [InputFileFolder]
+    ,L1.[OutputL1CuratedFile] AS [InputFile]
+    ,L1.[OutputDWTable] AS [InputDWTable]
+    ,'gold.Mirror_'+ Trim(I.StreamName) + '_monthly_snapshot'  AS [OutputDWTable]
+    ,'overwrite' AS [OutputDWTableWriteMode]
+    , 1 AS [ActiveFlag]
+FROM [ELT].[L1TransformDefinition] L1
+INNER JOIN [ELT].[IngestDefinition] I ON L1.IngestID = I.IngestID
+    AND I.SourceSystemName='WWI-mirror'
+    AND I.WatermarkColName IS NOT NULL --Only for transaction tables
+    AND I.ActiveFlag=1
+WHERE L1.ActiveFlag=1;
+
+MERGE INTO [ELT].[L2TransformDefinition] AS TARGET
+USING #ASQLMirror_L2TransformDefinition AS SOURCE  
+ON TARGET.OutputDWTable = SOURCE.OutputDWTable
+AND TARGET.InputDWTable = SOURCE.InputDWTable
+WHEN MATCHED THEN 
+    UPDATE SET 
+        TARGET.IngestID = SOURCE.IngestID,
+        TARGET.L1TransformID = SOURCE.L1TransformID,
+        TARGET.ComputeName = SOURCE.ComputeName,
+        TARGET.InputFileSystem = SOURCE.InputFileSystem,
+        TARGET.InputFileFolder = SOURCE.InputFileFolder,
+        TARGET.InputFile = SOURCE.InputFile,
+        TARGET.InputDWTable = SOURCE.InputDWTable,
+        TARGET.OutputDWTable = SOURCE.OutputDWTable,
+        TARGET.OutputDWTableWriteMode = SOURCE.OutputDWTableWriteMode,
+        TARGET.ActiveFlag = SOURCE.ActiveFlag
+WHEN NOT MATCHED BY TARGET THEN
+    INSERT (IngestID, 
+            L1TransformID, 
+            ComputeName, 
+            InputFileSystem, 
+            InputFileFolder, 
+            InputFile, 
+            InputDWTable, 
+            OutputDWTable, 
+            OutputDWTableWriteMode, 
+            ActiveFlag)
+    VALUES (IngestID, 
+            L1TransformID, 
+            ComputeName, 
+            InputFileSystem, 
+            InputFileFolder, 
+            InputFile, 
+            InputDWTable, 
+            OutputDWTable, 
+            OutputDWTableWriteMode, 
+            ActiveFlag);

--- a/elt-framework/ControlDB/Post Deployment Script/datasources/RestAPI/L1TransformDefinition/L1T_AzureRestAPI.sql
+++ b/elt-framework/ControlDB/Post Deployment Script/datasources/RestAPI/L1TransformDefinition/L1T_AzureRestAPI.sql
@@ -36,8 +36,8 @@ CREATE TABLE #AzureRestAPI_L1
 --Insert Into Temp Table
 INSERT INTO #AzureRestAPI_L1
 	SELECT  [IngestID]
-	,'L1Transform' AS [ComputePath]
-	,'L1Transform-Generic-Synapse' AS [ComputeName]
+	, NULL AS [ComputePath]
+	,'L1Transform-Generic-Fabric' AS [ComputeName]
 	, NULL AS [CustomParameters]
 	,[DestinationRawFileSystem] AS [InputRawFileSystem]
 	,[DestinationRawFolder] AS [InputRawFileFolder]

--- a/elt-framework/ControlDB/Post Deployment Script/datasources/RestAPI/L1TransformDefinition/L1T_PurviewRestAPI.sql
+++ b/elt-framework/ControlDB/Post Deployment Script/datasources/RestAPI/L1TransformDefinition/L1T_PurviewRestAPI.sql
@@ -36,8 +36,8 @@ CREATE TABLE #PurviewRestAPI_L1
 --Insert Into Temp Table
 INSERT INTO #PurviewRestAPI_L1
 	SELECT  [IngestID]
-	,'L1Transform' AS [ComputePath]
-	,'L1Transform-Generic-Synapse' AS [ComputeName]
+	,NULL AS [ComputePath]
+	,'L1Transform-Generic-Fabric' AS [ComputeName]
 	, NULL AS [CustomParameters]
 	,[DestinationRawFileSystem] AS [InputRawFileSystem]
 	,[DestinationRawFolder] AS [InputRawFileFolder]

--- a/elt-framework/ControlDB/Post Deployment Script/datasources/UploadFiles/L1TransformDefinition/L1T_CustomFormRecognizerModel.sql
+++ b/elt-framework/ControlDB/Post Deployment Script/datasources/UploadFiles/L1TransformDefinition/L1T_CustomFormRecognizerModel.sql
@@ -30,7 +30,7 @@ CREATE TABLE #CFRM_L1
 --Insert Into Temp Table
 INSERT INTO #CFRM_L1
 	SELECT  [IngestID]
-	,'L1Transform' AS [ComputePath]
+	,NULL AS [ComputePath]
 	,'L1Transform-ReStatement' AS [ComputeName]
 	,[DestinationRawFileSystem] AS [InputRawFileSystem]
 	,[DestinationRawFolder] AS [InputRawFileFolder]


### PR DESCRIPTION
This pull request introduces support for ingesting and transforming data from an Azure SQL Mirror source system ("WWI-mirror") into the ELT pipeline. It adds new post-deployment scripts and updates existing indexes and deployment logic to accommodate the new data source. The changes also generalize some transformation compute names and update index definitions to include the `OutputDWTable` column for uniqueness.

**Azure SQL Mirror integration:**

* Added a new `ASQLMirror` folder and three post-deployment scripts: `ASQLMirror_IngestDefinition.sql`, `ASQLMirror_L1TransformDefinition.sql`, and `ASQLMirror_L2TransformDefinition.sql`, which define ingestion and transformation logic for mirrored Azure SQL tables and ensure idempotent (re-runnable) deployment using `MERGE` statements. [[1]](diffhunk://#diff-a7d427cd033c214a5fb1e144351dee5505447888d452b16ed68f03cca34e3756R83) [[2]](diffhunk://#diff-a7d427cd033c214a5fb1e144351dee5505447888d452b16ed68f03cca34e3756R202-R210) [[3]](diffhunk://#diff-f9a10546d5b7624d9195e886b90e903da704ecbcf2dca91a7d017c6d175e4371R1-R182) [[4]](diffhunk://#diff-266fad66e1933dc2c7f1e25078f1054d49af6b119db9d33797fd69e0fd8096b9R1-R80) [[5]](diffhunk://#diff-bfa22c031607a1b74b670455283236f9a3aa07c4423fc98fe7bd94384a052eadR1-R71)
* Updated the main post-deployment script (`Script.PostDeployment.sql`) to include and execute the new ASQLMirror scripts, enabling their automatic application during deployments.

**Index and schema updates:**

* Modified unique index definitions for `L1TransformDefinition`, `L1TransformInstance`, `L2TransformDefinition`, and `L2TransformInstance` to include the `OutputDWTable` column, ensuring uniqueness when multiple output tables are involved. [[1]](diffhunk://#diff-e4107e944f2827f4c48ba197e27ed18cce5df530b52e387f5d7b8279116e004eL3-R3) [[2]](diffhunk://#diff-0d51d518adf9506697990f6a008b31187ea57715a2e3deb5275e3ea35c51616dL3-R3) [[3]](diffhunk://#diff-3357d4405f7016a8fd9695e91d04eceb952045c149930dfaa5b418f34790ed63L3-R3) [[4]](diffhunk://#diff-4c002225819e388f58dd0f688adc1deffd04b44c4af24339bbbd1425e5167c36L3-R3)

**Generalization and consistency improvements:**

* Changed the compute name for L1 transforms in RestAPI and UploadFiles sources from `'L1Transform-Generic-Synapse'` to `'L1Transform-Generic-Fabric'` and set `ComputePath` to `NULL` for consistency with new patterns. [[1]](diffhunk://#diff-1693f136cf8c7751a87233917edde3304038fd1d306ec49c6e2cf851d887b68aL39-R40) [[2]](diffhunk://#diff-97dd19a7e59f98cbbcc130f492eeb1e0549ea4c2e50db21bd6b235ebc7474e1eL39-R40) [[3]](diffhunk://#diff-859334162be5c04f077216b83b8bdba9e49c416ca69a4e8cc759a28cfb41032cL33-R33)