### PR TITLE
Add InputType to L2 transform mirror and adjust SP

### DIFF
--- a/elt-framework/ControlDB/ELT/Stored Procedures/GetTransformDefinition_L2.sql
+++ b/elt-framework/ControlDB/ELT/Stored Procedures/GetTransformDefinition_L2.sql
@@ -1,9 +1,8 @@
 ﻿CREATE PROCEDURE [ELT].[GetTransformDefinition_L2] 
 		@IngestID int, 
-		@DeltaDate datetime = null,
-		@InputType varchar(15) = '%'
+		@DeltaDate datetime = NULL,
+		@InputType varchar(15) = NULL
 AS
-	--declare @IngestID int
 	DECLARE @localdate datetime	= CONVERT(datetime,CONVERT(datetimeoffset, getdate()) at time zone 'AUS Eastern Standard Time')
 
 	--Should be using L2DeltaTransformDate, if null then LocalDate
@@ -86,7 +85,7 @@ AS
 			TD.[ActiveFlag] = 1
 			and ID.[ActiveFlag] = 1
 			and ID.[L2TransformationReqdFlag] =1
-			and TD.[InputType] like COALESCE(@InputType,TD.[InputType])
+			and (TD.[InputType] IS NULL OR TD.[InputType] = @InputType)
 
 GO
 			

--- a/elt-framework/ControlDB/Post Deployment Script/datasources/ASQLMirror/ASQLMirror_L2TransformDefinition.sql
+++ b/elt-framework/ControlDB/Post Deployment Script/datasources/ASQLMirror/ASQLMirror_L2TransformDefinition.sql
@@ -4,7 +4,8 @@ CREATE TABLE #ASQLMirror_L2TransformDefinition(
 	[IngestID] [int] NULL,
 	[L1TransformID] [int] NULL,
 	[ComputeName] [varchar](100) NULL,
-	[InputFileSystem] [varchar](50) NULL,
+    [InputType] [varchar](50) NULL,
+	[InputFileSystem] [varchar](15) NULL,
 	[InputFileFolder] [varchar](200) NULL,
 	[InputFile] [varchar](200) NULL,
 	[InputDWTable] [varchar](200) NULL,
@@ -18,6 +19,7 @@ SELECT
     L1.[IngestID]
     ,L1.[L1TransformID]
     ,'gold.mirror_create_'+ Trim(Lower(I.StreamName)) + '_monthly_snapshot'  AS [ComputeName]
+    ,'Curated' AS [InputType]
     ,L1.[OutputL1CurateFileSystem] AS [InputFileSystem]
     ,L1.[OutputL1CuratedFolder] AS [InputFileFolder]
     ,L1.[OutputL1CuratedFile] AS [InputFile]
@@ -41,6 +43,7 @@ WHEN MATCHED THEN
         TARGET.IngestID = SOURCE.IngestID,
         TARGET.L1TransformID = SOURCE.L1TransformID,
         TARGET.ComputeName = SOURCE.ComputeName,
+        TARGET.InputType = SOURCE.InputType,
         TARGET.InputFileSystem = SOURCE.InputFileSystem,
         TARGET.InputFileFolder = SOURCE.InputFileFolder,
         TARGET.InputFile = SOURCE.InputFile,
@@ -52,6 +55,7 @@ WHEN NOT MATCHED BY TARGET THEN
     INSERT (IngestID, 
             L1TransformID, 
             ComputeName, 
+            InputType,
             InputFileSystem, 
             InputFileFolder, 
             InputFile, 
@@ -62,6 +66,7 @@ WHEN NOT MATCHED BY TARGET THEN
     VALUES (IngestID, 
             L1TransformID, 
             ComputeName, 
+            InputType,
             InputFileSystem, 
             InputFileFolder, 
             InputFile, 


### PR DESCRIPTION
Expose and persist InputType for L2 transforms and tighten matching logic. Updates GetTransformDefinition_L2: change @InputType default to NULL, normalize @DeltaDate default, remove a stray comment, and replace a LIKE/COALESCE filter with explicit matching (allowing TD.InputType NULL or exact match). Updates ASQLMirror_L2TransformDefinition: add InputType column to temp table, set InputType='Curated' in the SELECT, include InputType in MERGE's UPDATE and INSERT, and reduce InputFileSystem length to 15. These changes ensure InputType is tracked and filtering is more deterministic.