### PR TITLE
Refine InputType filter logic in GetTransformDefinition_L2

### DIFF
--- a/elt-framework/ControlDB/ELT/Stored Procedures/GetTransformDefinition_L2.sql
+++ b/elt-framework/ControlDB/ELT/Stored Procedures/GetTransformDefinition_L2.sql
@@ -85,7 +85,7 @@ AS
 			TD.[ActiveFlag] = 1
 			and ID.[ActiveFlag] = 1
 			and ID.[L2TransformationReqdFlag] =1
-			and (TD.[InputType] IS NULL OR TD.[InputType] = @InputType)
+			and TD.[InputType] = COALESCE(@InputType,TD.[InputType])
 
 GO
 			


### PR DESCRIPTION
Updated WHERE clause to use COALESCE for InputType, ensuring exact match when @InputType is provided and preserving existing value when it is NULL. This replaces the previous logic that allowed NULL or matching InputType values.